### PR TITLE
fix(validate): restore lax whitespace validation for customer migration

### DIFF
--- a/workflow/validate/validate.go
+++ b/workflow/validate/validate.go
@@ -716,32 +716,30 @@ func resolveAllVariables(scope map[string]interface{}, globalParams map[string]s
 	_, allowAllWorkflowOutputParameterRefs := scope[anyWorkflowOutputParameterMagicValue]
 	_, allowAllWorkflowOutputArtifactRefs := scope[anyWorkflowOutputArtifactMagicValue]
 	return template.Validate(tmplStr, func(tag string) error {
-		// Trim the tag to check the validations
-		trimmedTag := strings.TrimSpace(tag)
 		// Skip the custom variable references
-		if !checkValidWorkflowVariablePrefix(trimmedTag) {
+		if !checkValidWorkflowVariablePrefix(tag) {
 			return nil
 		}
-		_, ok := scope[trimmedTag]
-		_, isGlobal := globalParams[trimmedTag]
+		_, ok := scope[tag]
+		_, isGlobal := globalParams[tag]
 		if !ok && !isGlobal {
-			if (trimmedTag == "item" || strings.HasPrefix(trimmedTag, "item.")) && allowAllItemRefs {
+			if (tag == "item" || strings.HasPrefix(tag, "item.")) && allowAllItemRefs {
 				// we are *probably* referencing a undetermined item using withParam
 				// NOTE: this is far from foolproof.
-			} else if strings.HasPrefix(trimmedTag, "workflow.outputs.parameters.") && allowAllWorkflowOutputParameterRefs {
+			} else if strings.HasPrefix(tag, "workflow.outputs.parameters.") && allowAllWorkflowOutputParameterRefs {
 				// Allow runtime resolution of workflow output parameter names
-			} else if strings.HasPrefix(trimmedTag, "workflow.outputs.artifacts.") && allowAllWorkflowOutputArtifactRefs {
+			} else if strings.HasPrefix(tag, "workflow.outputs.artifacts.") && allowAllWorkflowOutputArtifactRefs {
 				// Allow runtime resolution of workflow output artifact names
-			} else if strings.HasPrefix(trimmedTag, "outputs.") {
+			} else if strings.HasPrefix(tag, "outputs.") {
 				// We are self referencing for metric emission, allow it.
-			} else if strings.HasPrefix(trimmedTag, common.GlobalVarWorkflowCreationTimestamp) {
-			} else if strings.HasPrefix(trimmedTag, common.GlobalVarWorkflowCronScheduleTime) {
+			} else if strings.HasPrefix(tag, common.GlobalVarWorkflowCreationTimestamp) {
+			} else if strings.HasPrefix(tag, common.GlobalVarWorkflowCronScheduleTime) {
 				// Allow runtime resolution for "scheduledTime" which will pass from CronWorkflow
-			} else if strings.HasPrefix(trimmedTag, common.GlobalVarWorkflowDuration) {
-			} else if strings.HasPrefix(trimmedTag, "tasks.name") {
-			} else if strings.HasPrefix(trimmedTag, "steps.name") {
-			} else if strings.HasPrefix(trimmedTag, "node.name") {
-			} else if strings.HasPrefix(trimmedTag, "workflow.parameters") && workflowTemplateValidation {
+			} else if strings.HasPrefix(tag, common.GlobalVarWorkflowDuration) {
+			} else if strings.HasPrefix(tag, "tasks.name") {
+			} else if strings.HasPrefix(tag, "steps.name") {
+			} else if strings.HasPrefix(tag, "node.name") {
+			} else if strings.HasPrefix(tag, "workflow.parameters") && workflowTemplateValidation {
 				// If we are simply validating a WorkflowTemplate in isolation, some of the parameters may come from the Workflow that uses it
 			} else {
 				return fmt.Errorf("failed to resolve {{%s}}", tag)

--- a/workflow/validate/validate_test.go
+++ b/workflow/validate/validate_test.go
@@ -3351,8 +3351,31 @@ spec:
 
 func TestShouldCheckValidationToSpacedParameters(t *testing.T) {
 	err := validate(spacedParameterWorkflowTemplate)
-	// Do not allow leading or trailing spaces in parameters
-	require.ErrorContains(t, err, "failed to resolve {{  workflow.thisdoesnotexist  }}")
+	// Spaced references like {{  workflow.thisdoesnotexist  }} bypass prefix matching
+	// and are treated as custom variables — intentionally lax for customer migration.
+	require.NoError(t, err)
+}
+
+var wftmplWithUndeclaredSpacedParam = `
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: repro-lax-validation
+spec:
+  entrypoint: update-env
+  templates:
+    - name: update-env
+      container:
+        image: alpine:3.18
+        command: ["echo", "{{ inputs.parameters.chart-path }}"]
+`
+
+func TestUndeclaredSpacedParamPassesValidation(t *testing.T) {
+	// Templates referencing {{ inputs.parameters.foo }} with spaces, where foo is
+	// not declared in inputs.parameters, should pass validation in this build.
+	// This restores the lax behaviour from v3.4.6 to ease customer template migration.
+	err := validateWorkflowTemplate(wftmplWithUndeclaredSpacedParam, ValidateOpts{})
+	require.NoError(t, err)
 }
 
 var parameterizedGlobalArtifactsWorkflow = `


### PR DESCRIPTION
Fixes #N/A

### Motivation

Templates using spaced variable references like `{{ inputs.parameters.foo }}` where `foo` is
not declared in the template's `inputs.parameters` were failing validation with:

```
failed to resolve {{ inputs.parameters.foo }}
```

Upstream PR argoproj/argo-workflows#11781 (commit `07c256085`) introduced a correct bug fix
that added `strings.TrimSpace(tag)` in `resolveAllVariables`. However, some existing users were
inadvertently relying on the pre-fix behaviour, causing validation failures after upgrading.

This is an intentional, scoped revert for the akuity `release-3.7.10` branch to restore the
lax v3.4.6 behaviour and ease user template migration. Not intended for upstream contribution.

### Modifications

- Removed `trimmedTag := strings.TrimSpace(tag)` in `resolveAllVariables` in `workflow/validate/validate.go`
- Reverted all `trimmedTag` usages back to `tag`
- Non-spaced references like `{{inputs.parameters.foo}}` are unaffected and retain strict validation

### Verification

1. **Reproduced** — added `TestUndeclaredSpacedParamPassesValidation` with a WorkflowTemplate referencing
   `{{ inputs.parameters.chart-path }}` (undeclared, with spaces). Confirmed it **fails** with
   `templates.update-env: failed to resolve {{ inputs.parameters.chart-path }}` on unmodified code.
2. **Unfixed** — applied the revert to `resolveAllVariables`.
3. **Verified** — the repro test now passes. Updated `TestShouldCheckValidationToSpacedParameters`
   (added by PR #11781) to reflect the restored lax behaviour.
4. Full `./workflow/...` test suite run — all 37 packages pass, zero failures.

### Documentation

No documentation changes needed — this is a scoped internal revert, not a new feature.