### PR TITLE
fix(security): cherry-pick CVE-2026-31892 and CVE-2026-28229 fixes

### DIFF
--- a/server/clusterworkflowtemplate/cluster_workflow_template_server.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterwftmplpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
@@ -52,6 +53,13 @@ func (cwts *ClusterWorkflowTemplateServer) CreateClusterWorkflowTemplate(ctx con
 }
 
 func (cwts *ClusterWorkflowTemplateServer) GetClusterWorkflowTemplate(ctx context.Context, req *clusterwftmplpkg.ClusterWorkflowTemplateGetRequest) (*v1alpha1.ClusterWorkflowTemplate, error) {
+	allowed, err := auth.CanI(ctx, "get", "clusterworkflowtemplates", "", req.Name)
+	if err != nil {
+		return nil, serverutils.ToStatusError(err, codes.Internal)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
 	wfTmpl, err := cwts.getTemplateAndValidate(ctx, req.Name)
 	if err != nil {
 		return nil, serverutils.ToStatusError(err, codes.Internal)

--- a/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
+++ b/server/clusterworkflowtemplate/cluster_workflow_template_server_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	clusterwftmplpkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/clusterworkflowtemplate"
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -151,6 +154,11 @@ const userEmailLabel = "my-sub.at.your.org"
 
 func getClusterWorkflowTemplateServer() (clusterwftmplpkg.ClusterWorkflowTemplateServiceServer, context.Context) {
 	kubeClientSet := fake.NewSimpleClientset()
+	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
 	wfClientset := wftFake.NewSimpleClientset(&unlabelled, &cwftObj2, &cwftObj3)
 	ctx := context.WithValue(context.WithValue(context.WithValue(context.TODO(), auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"})
 	return NewClusterWorkflowTemplateServer(instanceid.NewService("my-instanceid"), nil, nil), ctx
@@ -202,6 +210,25 @@ func TestWorkflowTemplateServer_GetClusterWorkflowTemplate(t *testing.T) {
 			Name: "cluster-workflow-template-whalesay-template",
 		})
 		require.Error(t, err)
+	})
+	t.Run("Unauthorized", func(t *testing.T) {
+		kubeClientSet := fake.NewSimpleClientset()
+		kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false},
+			}, nil
+		})
+		wfClientset := wftFake.NewSimpleClientset(&cwftObj2)
+		ctx := context.WithValue(context.WithValue(context.WithValue(context.TODO(),
+			auth.WfKey, wfClientset),
+			auth.KubeKey, kubeClientSet),
+			auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
+		server := NewClusterWorkflowTemplateServer(instanceid.NewService("my-instanceid"), nil, nil)
+		_, err := server.GetClusterWorkflowTemplate(ctx, &clusterwftmplpkg.ClusterWorkflowTemplateGetRequest{
+			Name: "cluster-workflow-template-whalesay-template2",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PermissionDenied")
 	})
 }
 

--- a/server/workflowtemplate/workflow_template_server.go
+++ b/server/workflowtemplate/workflow_template_server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
@@ -58,6 +59,13 @@ func (wts *WorkflowTemplateServer) CreateWorkflowTemplate(ctx context.Context, r
 }
 
 func (wts *WorkflowTemplateServer) GetWorkflowTemplate(ctx context.Context, req *workflowtemplatepkg.WorkflowTemplateGetRequest) (*v1alpha1.WorkflowTemplate, error) {
+	allowed, err := auth.CanI(ctx, "get", "workflowtemplates", req.Namespace, req.Name)
+	if err != nil {
+		return nil, sutils.ToStatusError(err, codes.Internal)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "permission denied")
+	}
 	wfTmpl, err := wts.getTemplateAndValidate(ctx, req.Namespace, req.Name)
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/workflowtemplate/workflow_template_server_test.go
+++ b/server/workflowtemplate/workflow_template_server_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	workflowtemplatepkg "github.com/argoproj/argo-workflows/v3/pkg/apiclient/workflowtemplate"
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -171,6 +174,11 @@ func getWorkflowTemplateServer() (workflowtemplatepkg.WorkflowTemplateServiceSer
 	v1alpha1.MustUnmarshal(wftStr2, &wftObj1)
 	v1alpha1.MustUnmarshal(wftStr3, &wftObj2)
 	kubeClientSet := fake.NewSimpleClientset()
+	kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
 	wfClientset := wftFake.NewSimpleClientset(&unlabelledObj, &wftObj1, &wftObj2)
 	ctx := context.WithValue(context.WithValue(context.WithValue(context.TODO(), auth.WfKey, wfClientset), auth.KubeKey, kubeClientSet), auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}, Email: "my-sub@your.org"})
 	wftmplStore := NewWorkflowTemplateClientStore()
@@ -225,6 +233,30 @@ func TestWorkflowTemplateServer_GetWorkflowTemplate(t *testing.T) {
 	t.Run("Unlabelled", func(t *testing.T) {
 		_, err := server.GetWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateGetRequest{Name: "unlabelled", Namespace: "default"})
 		require.Error(t, err)
+	})
+	t.Run("Unauthorized", func(t *testing.T) {
+		kubeClientSet := fake.NewSimpleClientset()
+		kubeClientSet.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false},
+			}, nil
+		})
+		var wftObj1 v1alpha1.WorkflowTemplate
+		v1alpha1.MustUnmarshal(wftStr2, &wftObj1)
+		wfClientset := wftFake.NewSimpleClientset(&wftObj1)
+		ctx := context.WithValue(context.WithValue(context.WithValue(context.TODO(),
+			auth.WfKey, wfClientset),
+			auth.KubeKey, kubeClientSet),
+			auth.ClaimsKey, &types.Claims{Claims: jwt.Claims{Subject: "my-sub"}})
+		wftmplStore := NewWorkflowTemplateClientStore()
+		cwftmplStore := clusterworkflowtemplate.NewClusterWorkflowTemplateClientStore()
+		server := NewWorkflowTemplateServer(instanceid.NewService("my-instanceid"), wftmplStore, cwftmplStore)
+		_, err := server.GetWorkflowTemplate(ctx, &workflowtemplatepkg.WorkflowTemplateGetRequest{
+			Name:      "workflow-template-whalesay-template2",
+			Namespace: "default",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "PermissionDenied")
 	})
 }
 

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -4183,6 +4183,14 @@ func (woc *wfOperationCtx) retryStrategy(tmpl *wfv1.Template) *wfv1.RetryStrateg
 
 func (woc *wfOperationCtx) setExecWorkflow(ctx context.Context) error {
 	if woc.wf.Spec.WorkflowTemplateRef != nil { // not-woc-misuse
+		// When workflow restrictions require template referencing (Strict/Secure mode),
+		// reject workflows that include a podSpecPatch as it could override security
+		// settings defined in the WorkflowTemplate.
+		if woc.controller.Config.WorkflowRestrictions.MustUseReference() && woc.wf.Spec.HasPodSpecPatch() { // not-woc-misuse: intentionally checking the user-submitted spec
+			err := fmt.Errorf("podSpecPatch is not permitted when using workflowTemplateRef with templateReferencing restriction")
+			woc.markWorkflowError(ctx, err)
+			return err
+		}
 		err := woc.setStoredWfSpec(ctx)
 		if err != nil {
 			woc.markWorkflowError(ctx, err)

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5653,6 +5653,69 @@ func TestValidReferenceMode(t *testing.T) {
 	assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
 }
 
+func TestReferenceModeBlocksPodSpecPatch(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow("@testdata/workflow-template-ref.yaml")
+	wfTmpl := wfv1.MustUnmarshalWorkflowTemplate("@testdata/workflow-template-submittable.yaml")
+
+	t.Run("Strict rejects podSpecPatch", func(t *testing.T) {
+		wfWithPatch := wf.DeepCopy()
+		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","securityContext":{"privileged":true}}]}`
+		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		defer cancel()
+
+		ctx := logging.TestContext(t.Context())
+		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
+			TemplateReferencing: config.TemplateReferencingStrict,
+		}
+		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+		assert.Contains(t, woc.wf.Status.Message, "podSpecPatch is not permitted")
+	})
+
+	t.Run("Secure rejects podSpecPatch", func(t *testing.T) {
+		wfWithPatch := wf.DeepCopy()
+		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","securityContext":{"runAsUser":0}}]}`
+		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		defer cancel()
+
+		ctx := logging.TestContext(t.Context())
+		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
+			TemplateReferencing: config.TemplateReferencingSecure,
+		}
+		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
+		assert.Contains(t, woc.wf.Status.Message, "podSpecPatch is not permitted")
+	})
+
+	t.Run("No restrictions allows podSpecPatch", func(t *testing.T) {
+		wfWithPatch := wf.DeepCopy()
+		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","resources":{"limits":{"cpu":"1"}}}]}`
+		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		defer cancel()
+
+		ctx := logging.TestContext(t.Context())
+		controller.Config.WorkflowRestrictions = nil
+		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+	})
+
+	t.Run("Without podSpecPatch still works in Strict mode", func(t *testing.T) {
+		cancel, controller := newController(logging.TestContext(t.Context()), wf, wfTmpl)
+		defer cancel()
+
+		ctx := logging.TestContext(t.Context())
+		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
+			TemplateReferencing: config.TemplateReferencingStrict,
+		}
+		woc := newWorkflowOperationCtx(ctx, wf, controller)
+		woc.operate(ctx)
+		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
+	})
+}
+
 var workflowStatusMetric = `
 metadata:
   name: retry-to-completion-rngcr

--- a/workflow/controller/operator_test.go
+++ b/workflow/controller/operator_test.go
@@ -5660,14 +5660,14 @@ func TestReferenceModeBlocksPodSpecPatch(t *testing.T) {
 	t.Run("Strict rejects podSpecPatch", func(t *testing.T) {
 		wfWithPatch := wf.DeepCopy()
 		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","securityContext":{"privileged":true}}]}`
-		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		cancel, controller := newController(wfWithPatch, wfTmpl)
 		defer cancel()
 
-		ctx := logging.TestContext(t.Context())
+		ctx := context.Background()
 		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
 			TemplateReferencing: config.TemplateReferencingStrict,
 		}
-		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc := newWorkflowOperationCtx(wfWithPatch, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
 		assert.Contains(t, woc.wf.Status.Message, "podSpecPatch is not permitted")
@@ -5676,14 +5676,14 @@ func TestReferenceModeBlocksPodSpecPatch(t *testing.T) {
 	t.Run("Secure rejects podSpecPatch", func(t *testing.T) {
 		wfWithPatch := wf.DeepCopy()
 		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","securityContext":{"runAsUser":0}}]}`
-		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		cancel, controller := newController(wfWithPatch, wfTmpl)
 		defer cancel()
 
-		ctx := logging.TestContext(t.Context())
+		ctx := context.Background()
 		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
 			TemplateReferencing: config.TemplateReferencingSecure,
 		}
-		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc := newWorkflowOperationCtx(wfWithPatch, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowError, woc.wf.Status.Phase)
 		assert.Contains(t, woc.wf.Status.Message, "podSpecPatch is not permitted")
@@ -5692,25 +5692,25 @@ func TestReferenceModeBlocksPodSpecPatch(t *testing.T) {
 	t.Run("No restrictions allows podSpecPatch", func(t *testing.T) {
 		wfWithPatch := wf.DeepCopy()
 		wfWithPatch.Spec.PodSpecPatch = `{"containers":[{"name":"main","resources":{"limits":{"cpu":"1"}}}]}`
-		cancel, controller := newController(logging.TestContext(t.Context()), wfWithPatch, wfTmpl)
+		cancel, controller := newController(wfWithPatch, wfTmpl)
 		defer cancel()
 
-		ctx := logging.TestContext(t.Context())
+		ctx := context.Background()
 		controller.Config.WorkflowRestrictions = nil
-		woc := newWorkflowOperationCtx(ctx, wfWithPatch, controller)
+		woc := newWorkflowOperationCtx(wfWithPatch, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 	})
 
 	t.Run("Without podSpecPatch still works in Strict mode", func(t *testing.T) {
-		cancel, controller := newController(logging.TestContext(t.Context()), wf, wfTmpl)
+		cancel, controller := newController(wf, wfTmpl)
 		defer cancel()
 
-		ctx := logging.TestContext(t.Context())
+		ctx := context.Background()
 		controller.Config.WorkflowRestrictions = &config.WorkflowRestrictions{
 			TemplateReferencing: config.TemplateReferencingStrict,
 		}
-		woc := newWorkflowOperationCtx(ctx, wf, controller)
+		woc := newWorkflowOperationCtx(wf, controller)
 		woc.operate(ctx)
 		assert.Equal(t, wfv1.WorkflowRunning, woc.wf.Status.Phase)
 	})


### PR DESCRIPTION
Fixes #N/A

### Motivation

The akuity v3.7.10 build currently covers 4 of the 6 CVEs that are fixed in v3.7.11. Two High-severity first-party security fixes are only present in the upstream \`release-3.7.11\` branch:

- **CVE-2026-31892** — \`podSpecPatch\` bypasses \`templateReferencing\` (Strict/Secure) restrictions on user-submitted Workflows. Advisory: https://github.com/argoproj/argo-workflows/security/advisories/GHSA-3wf5-g532-rcrr
- **CVE-2026-28229** — Informer-based caching in WorkflowTemplate / ClusterWorkflowTemplate servers bypasses caller authorization checks. Advisory: https://github.com/argoproj/argo-workflows/security/advisories/GHSA-56px-hm34-xqj5

We cannot simply move users to v3.7.11 because v3.7.11 introduces a separate runtime-breaking change (commit \`477442702\` — strict expression resolution for \`tasks.*\`/\`steps.*\`). This PR cherry-picks just the two security fixes without pulling in the runtime breakage.

### Modifications

- Cherry-pick \`9064c7f89\` — CVE-2026-31892 podSpecPatch security check (8-line addition to \`workflow/controller/operator.go\` + tests)
- Cherry-pick \`8f505a558\` — CVE-2026-28229 \`auth.CanI()\` checks in informer cache paths (\`server/clusterworkflowtemplate/\`, \`server/workflowtemplate/\`)
- One follow-up commit adapts the \`TestReferenceModeBlocksPodSpecPatch\` test to \`release-3.7.10\`'s API (the upstream test was written against a newer \`logging\` package and 3-arg \`newWorkflowOperationCtx\` signature that don't exist on this branch). The security fix in \`operator.go\` is untouched.

### Verification

- Both cherry-picks applied cleanly with no merge conflicts
- New \`TestReferenceModeBlocksPodSpecPatch\` test (4 sub-tests) — all pass after API adaptation
- Existing auth tests in \`server/clusterworkflowtemplate\` and \`server/workflowtemplate\` — pass
- Full \`./workflow/...\` and \`./server/...\` regression sweep — green (only pre-existing unrelated UI bundle failures in \`server/apiserver\` and \`server/static\` from missing local UI build, unrelated to these changes)

### Documentation

No documentation changes needed — these are scoped security backports.